### PR TITLE
Add vagrant provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 
 # Ignore
 /.idea/*
+/.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+Vagrant.configure('2') do |config|
+  config.vm.box      = 'ubuntu/wily64'
+  config.vm.hostname = 'rails-dev-box'
+
+  config.vm.network :forwarded_port, guest: 3000, host: 3000
+
+  config.vm.provision :shell, path: 'bootstrap.sh', keep_color: true
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+    v.cpus = 2
+  end
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,53 @@
+# The output of all these installation steps is noisy. With this utility
+# the progress report is nice and concise.
+function install {
+    echo installing $1
+    shift
+    apt-get -y install "$@" >/dev/null 2>&1
+}
+
+echo adding swap file
+fallocate -l 2G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap defaults 0 0' >> /etc/fstab
+
+echo updating package information
+apt-add-repository -y ppa:brightbox/ruby-ng >/dev/null 2>&1
+apt-get -y update >/dev/null 2>&1
+
+install 'development tools' build-essential
+
+install Ruby ruby2.3 ruby2.3-dev
+update-alternatives --set ruby /usr/bin/ruby2.3 >/dev/null 2>&1
+update-alternatives --set gem /usr/bin/gem2.3 >/dev/null 2>&1
+
+echo installing Bundler
+gem install bundler -N >/dev/null 2>&1
+
+install Git git
+install SQLite sqlite3 libsqlite3-dev
+install memcached memcached
+#install Redis redis-server
+#install RabbitMQ rabbitmq-server
+
+install PostgreSQL postgresql postgresql-contrib libpq-dev
+sudo -u postgres createuser --superuser vagrant
+sudo -u postgres createdb -O vagrant activerecord_unittest
+sudo -u postgres createdb -O vagrant activerecord_unittest2
+
+install 'Nokogiri dependencies' libxml2 libxml2-dev libxslt1-dev
+install 'ExecJS runtime' nodejs
+
+# Needed for docs generation.
+update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8
+
+# Install githug
+gem install specific_install
+gem specific_install -l https://github.com/m3brown/githug
+
+# Bundle install
+cd /vagrant && bundle install
+
+echo 'all set, rock on!'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # enable vagrant ip ranges in dev
+  config.web_console.whitelisted_ips = '10.0.0.0/16'
 end


### PR DESCRIPTION
- Vagrantfile and bootstrap based off of https://github.com/rails/rails-dev-box
 - Remove redis, rabbitmq, and mysql to save time
 - Bootstrap also installed my fork of githug (https://github.com/m3brown/githug)
 - Bootstrap also runs bundle install in /vagrant to save the developers one step
- Whitelist `10.0.*.*` IPs in rails for vagrant machines